### PR TITLE
Feature/return only delegated preps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9014,6 +9014,7 @@
       "version": "6.5.3",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
       "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
+      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9014,7 +9014,6 @@
       "version": "6.5.3",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
       "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
-      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "core-js": "^2.5.4",
     "icon-sdk-js": "0.0.16",
     "ng2-tooltip-directive": "^2.1.9",
-    "rxjs": "~6.5.1",
     "tslib": "^1.9.0",
     "zone.js": "~0.9.1"
   },

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "core-js": "^2.5.4",
     "icon-sdk-js": "0.0.16",
     "ng2-tooltip-directive": "^2.1.9",
+    "rxjs": "^6.5.3",
     "tslib": "^1.9.0",
     "zone.js": "~0.9.1"
   },

--- a/src/app/services/icon-contract/icon-contract.service.ts
+++ b/src/app/services/icon-contract/icon-contract.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
-import IconService, { HttpProvider, IconBuilder, IconConverter, IconAmount  } from 'icon-sdk-js';
+import IconService, { HttpProvider, IconBuilder } from 'icon-sdk-js';
 const { CallBuilder } = IconBuilder;
-import { PReps, PrepDetails, PRepDelegation, Delegations} from './preps';
+import { PReps, PrepDetails, DelegatedPRep, Delegations} from './preps';
 @Injectable({
   providedIn: 'root'
 })
@@ -44,6 +44,17 @@ export class IconContractService {
     return this.toBigInt(response['estimatedICX']);
   }
   
+  public async getPRep(address: string) {
+    const call = new CallBuilder()
+    .to('cx0000000000000000000000000000000000000000')
+    .method('getPRep')			
+    .params({address: address})		
+    .build();
+
+    return await this.iconService.call(call).execute();
+  }
+
+  
   public async getPReps() {
 	  const call = new CallBuilder()
       .to('cx0000000000000000000000000000000000000000')
@@ -56,7 +67,27 @@ export class IconContractService {
     preps.totalDelegated = this.toBigInt(response.totalDelegated);
     preps.totalStake = this.toBigInt(response.totalStake);
     preps.startRanking = this.toInt(response.startRanking);
-    preps.preps = response.preps.map((result: PrepDetails) => <PrepDetails>result);
+    preps.preps = [response.preps.length];
+
+    for (var i = 0; i < response.preps.length; i++) {
+      var item = response.preps[i];
+      var rep = new PrepDetails();
+      rep.name = item.name;
+      rep.address = item.address;
+      rep.city = item.city;
+      rep.delegated = this.toBigInt(item.delegated);
+      rep.grade = this.toInt(item.grade);
+      rep.irep = this.toBigInt(item.irep);
+      rep.irepUpdateBlockHeight = this.toInt(item.irepUpdateBlockHeight);
+      rep.lastGenerateBlockHeight = this.toInt(item.lastGenerateBlockHeight);
+      rep.stake = this.toInt(item.stake);
+      rep.status = this.toInt(item.status);
+      rep.totalBlocks = this.toInt(item.totalBlocks);
+      rep.validatedBlocks = this.toInt(item.validatedBlocks);
+      rep.rank = i;
+      preps[i] = rep;
+    }
+ debugger;
     return preps;
   }
 
@@ -68,10 +99,20 @@ export class IconContractService {
     .build();
 
     var response = await this.iconService.call(call).execute();
-    var delegationPRep = new PRepDelegation();
-    delegationPRep.totalDelegated = this.toBigInt(response.totalDelegated);
-    delegationPRep.votingPower = this.toBigInt(response.votingPower);
-    delegationPRep.delegations = response.delegations.map((result: Delegations) => <Delegations>result);
-    return delegationPRep;
+    var delegatedPRep = new DelegatedPRep();
+    delegatedPRep.totalDelegated = this.toBigInt(response.totalDelegated);
+    delegatedPRep.votingPower = this.toBigInt(response.votingPower);
+    delegatedPRep.delegations = [response.delegations.length];
+    for (var i = 0; i < response.delegations.length; i++) {
+      var item = response.delegations[i];
+      var delegate = new Delegations();
+      delegate.address = item.address;
+      delegate.value = this.toBigInt(item.value);
+      delegatedPRep[i] = delegate;
+    }
+
+    debugger;
+
+    return delegatedPRep; 
   }
 }

--- a/src/app/services/icon-contract/icon-contract.service.ts
+++ b/src/app/services/icon-contract/icon-contract.service.ts
@@ -44,17 +44,6 @@ export class IconContractService {
     return this.toBigInt(response['estimatedICX']);
   }
   
-  public async getPRep(address: string) {
-    const call = new CallBuilder()
-    .to('cx0000000000000000000000000000000000000000')
-    .method('getPRep')			
-    .params({address: address})		
-    .build();
-
-    return await this.iconService.call(call).execute();
-  }
-
-  
   public async getPReps() {
 	  const call = new CallBuilder()
       .to('cx0000000000000000000000000000000000000000')

--- a/src/app/services/icon-contract/icon-contract.service.ts
+++ b/src/app/services/icon-contract/icon-contract.service.ts
@@ -81,7 +81,7 @@ export class IconContractService {
         rep.name = item.name;
         rep.address = item.address;
         rep.city = item.city;
-        rep.delegated = this.toBigInt(item.delegated);
+        rep.totalDelegated = this.toBigInt(item.delegated);
         rep.grade = this.toInt(item.grade);
         rep.irep = this.toBigInt(item.irep);
         rep.irepUpdateBlockHeight = this.toInt(item.irepUpdateBlockHeight);
@@ -102,7 +102,7 @@ export class IconContractService {
         rep.name = item.name;
         rep.address = item.address;
         rep.city = item.city;
-        rep.delegated = this.toBigInt(item.delegated);
+        rep.totalDelegated = this.toBigInt(item.delegated);
         rep.grade = this.toInt(item.grade);
         rep.irep = this.toBigInt(item.irep);
         rep.irepUpdateBlockHeight = this.toInt(item.irepUpdateBlockHeight);
@@ -129,6 +129,7 @@ export class IconContractService {
     const response = await this.iconService.call(call).execute();
     for(let p of response.delegations) {
         this.getPReps(p.address, true).then(result => { 
+           result[0].userDelegated = this.toBigInt(p.value);
            dPrep.push(result);
         });
      }

--- a/src/app/services/icon-contract/icon-contract.service.ts
+++ b/src/app/services/icon-contract/icon-contract.service.ts
@@ -87,7 +87,6 @@ export class IconContractService {
       rep.rank = i;
       preps[i] = rep;
     }
- debugger;
     return preps;
   }
 
@@ -110,9 +109,6 @@ export class IconContractService {
       delegate.value = this.toBigInt(item.value);
       delegatedPRep[i] = delegate;
     }
-
-    debugger;
-
     return delegatedPRep; 
   }
 }

--- a/src/app/services/icon-contract/icon-contract.service.ts
+++ b/src/app/services/icon-contract/icon-contract.service.ts
@@ -1,8 +1,7 @@
 import { Injectable } from '@angular/core';
 import IconService, { HttpProvider, IconBuilder, IconConverter, IconAmount  } from 'icon-sdk-js';
 const { CallBuilder } = IconBuilder;
-import { PReps, DelegatedPRep } from './preps';
-
+import { PReps, PrepDetails, PRepDelegation, Delegations} from './preps';
 @Injectable({
   providedIn: 'root'
 })
@@ -56,7 +55,7 @@ export class IconContractService {
   }
 
   
-  public async getPReps(address: string, delegated: true) {
+  public async getPReps() {
 	  const call = new CallBuilder()
       .to('cx0000000000000000000000000000000000000000')
       .method('getPReps')			
@@ -64,57 +63,11 @@ export class IconContractService {
 
     var response = await this.iconService.call(call).execute();
     var preps = new PReps();
-    //count is used to hold the number array index of delegated PReps;
-    var count = 0;
     preps.blockHeight = this.toInt(response.blockHeight);
     preps.totalDelegated = this.toBigInt(response.totalDelegated);
     preps.totalStake = this.toBigInt(response.totalStake);
     preps.startRanking = this.toInt(response.startRanking);
-    preps.preps = [response.preps.length];
-
-    for (var i = 0; i < response.preps.length; i++) {
-      var item = response.preps[i];
-      //only return ones that have been delegated by the public address holder
-      if(delegated) {
-       if(item.address === address) {
-        var rep = new DelegatedPRep();
-        rep.name = item.name;
-        rep.address = item.address;
-        rep.city = item.city;
-        rep.totalDelegated = this.toBigInt(item.delegated);
-        rep.grade = this.toInt(item.grade);
-        rep.irep = this.toBigInt(item.irep);
-        rep.irepUpdateBlockHeight = this.toInt(item.irepUpdateBlockHeight);
-        rep.lastGenerateBlockHeight = this.toInt(item.lastGenerateBlockHeight);
-        rep.stake = this.toInt(item.stake);
-        rep.status = this.toInt(item.status);
-        rep.totalBlocks = this.toInt(item.totalBlocks);
-        rep.validatedBlocks = this.toInt(item.validatedBlocks);
-        //by default the list of preps is ordered from highest to lowest
-        //so we can use the order of the array to determine the ranking
-        rep.rank = i+1;
-        preps[count] = rep;
-        count++;
-       }
-      } else {
-        //we just want to return everything
-        var rep = new DelegatedPRep();
-        rep.name = item.name;
-        rep.address = item.address;
-        rep.city = item.city;
-        rep.totalDelegated = this.toBigInt(item.delegated);
-        rep.grade = this.toInt(item.grade);
-        rep.irep = this.toBigInt(item.irep);
-        rep.irepUpdateBlockHeight = this.toInt(item.irepUpdateBlockHeight);
-        rep.lastGenerateBlockHeight = this.toInt(item.lastGenerateBlockHeight);
-        rep.stake = this.toInt(item.stake);
-        rep.status = this.toInt(item.status);
-        rep.totalBlocks = this.toInt(item.totalBlocks);
-        rep.validatedBlocks = this.toInt(item.validatedBlocks);
-        rep.rank = i+1;
-        preps[i] = rep;
-       }
-    }
+    preps.preps = response.preps.map((result: PrepDetails) => <PrepDetails>result);
     return preps;
   }
 
@@ -125,14 +78,11 @@ export class IconContractService {
     .params({address: address})		
     .build();
 
-    let dPrep: PReps[] = [];
-    const response = await this.iconService.call(call).execute();
-    for(let p of response.delegations) {
-        this.getPReps(p.address, true).then(result => { 
-           result[0].userDelegated = this.toBigInt(p.value);
-           dPrep.push(result);
-        });
-     }
-     return dPrep;
+    var response = await this.iconService.call(call).execute();
+    var delegationPRep = new PRepDelegation();
+    delegationPRep.totalDelegated = this.toBigInt(response.totalDelegated);
+    delegationPRep.votingPower = this.toBigInt(response.votingPower);
+    delegationPRep.delegations = response.delegations.map((result: Delegations) => <Delegations>result);
+    return delegationPRep;
   }
 }

--- a/src/app/services/icon-contract/preps.ts
+++ b/src/app/services/icon-contract/preps.ts
@@ -23,7 +23,7 @@ export class PReps {
     startRanking: number;
 }
 
-export class PRepDelegation {
+export class DelegatedPRep {
     totalDelegated: number;
     votingPower: number;
     delegations: Delegations[];

--- a/src/app/services/icon-contract/preps.ts
+++ b/src/app/services/icon-contract/preps.ts
@@ -1,9 +1,8 @@
-export class DelegatedPRep {
+export class PrepDetails {
     address: string;
     city: string;
     country: string;
-    totalDelegated: number;
-    userDelegated : number;
+    delegated: number;
     grade: number;
     irep: number;
     irepUpdateBlockHeight: number;
@@ -14,13 +13,23 @@ export class DelegatedPRep {
     totalBlocks: number;
     validatedBlocks: number;
     rank: number;
-    
 }
 
 export class PReps {
     totalDelegated: number;
     totalStake: number;
-    preps: DelegatedPRep[];
+    preps: PrepDetails[];
     blockHeight: number;
     startRanking: number;
+}
+
+export class PRepDelegation {
+    totalDelegated: number;
+    votingPower: number;
+    delegations: Delegations[];
+}
+
+export class Delegations {
+    address: string;
+    value: number;
 }

--- a/src/app/services/icon-contract/preps.ts
+++ b/src/app/services/icon-contract/preps.ts
@@ -2,7 +2,8 @@ export class DelegatedPRep {
     address: string;
     city: string;
     country: string;
-    delegated: number;
+    totalDelegated: number;
+    userDelegated : number;
     grade: number;
     irep: number;
     irepUpdateBlockHeight: number;
@@ -13,6 +14,7 @@ export class DelegatedPRep {
     totalBlocks: number;
     validatedBlocks: number;
     rank: number;
+    
 }
 
 export class PReps {

--- a/src/app/services/icon-contract/preps.ts
+++ b/src/app/services/icon-contract/preps.ts
@@ -12,6 +12,7 @@ export class DelegatedPRep {
     status: number;
     totalBlocks: number;
     validatedBlocks: number;
+    rank: number;
 }
 
 export class PReps {

--- a/src/app/tab2/preps.page.ts
+++ b/src/app/tab2/preps.page.ts
@@ -4,7 +4,7 @@ import { ToastController } from '@ionic/angular';
 import { Chart } from 'chart.js';
 import 'chartjs-plugin-labels';
 import { IconContractService } from '../services/icon-contract/icon-contract.service';
-import { PRepDelegation, PReps } from '../services/icon-contract/preps';
+import { DelegatedPRep, PReps } from '../services/icon-contract/preps';
 
 
 @Component({
@@ -18,7 +18,7 @@ export class PrepsPage implements OnInit {
   @ViewChild('dnChart', {static:false}) dnChart: ElementRef;
   rows: Object;
   dn: Chart;
-  public delegatedPrep: PRepDelegation;
+  public delegatedPrep: DelegatedPRep;
   public preps: PReps;
 
   public address: string;

--- a/src/app/tab2/preps.page.ts
+++ b/src/app/tab2/preps.page.ts
@@ -4,7 +4,8 @@ import { ToastController } from '@ionic/angular';
 import { Chart } from 'chart.js';
 import 'chartjs-plugin-labels';
 import { IconContractService } from '../services/icon-contract/icon-contract.service';
-import { DelegatedPRep, PReps } from '../services/icon-contract/preps';
+import { PRepDelegation, PReps } from '../services/icon-contract/preps';
+
 
 @Component({
   selector: 'app-preps',
@@ -17,6 +18,8 @@ export class PrepsPage implements OnInit {
   @ViewChild('dnChart', {static:false}) dnChart: ElementRef;
   rows: Object;
   dn: Chart;
+  public delegatedPrep: PRepDelegation;
+  public preps: PReps;
 
   public address: string;
 
@@ -24,15 +27,17 @@ export class PrepsPage implements OnInit {
                private iconContract: IconContractService) {}
 
   ngAfterViewInit() {
-     this.createDnChart();
+     this.createDnChart();  
   }
 
   ngOnInit() {
     this.storage.get('address').then(address => {
       this.address = address;     
+      this.getAllPreps();
       this.getMyPreps();
     });
-     
+
+
 
      this.rows = [
       {
@@ -57,12 +62,15 @@ export class PrepsPage implements OnInit {
   }
 
   async getMyPreps() {
-    this.iconContract.getDelegatedPReps(this.address).then(result => {
-      console.log(result);
-    });
+    this.delegatedPrep = await this.iconContract.getDelegatedPReps(this.address);
+  }
+
+   async getAllPreps() {
+      this.preps = await this.iconContract.getPReps();
    }
 
   createDnChart() {
+
     this.dn = new Chart(this.dnChart.nativeElement, {
       type: 'pie',
       circumference: Math.PI,

--- a/src/app/tab2/preps.page.ts
+++ b/src/app/tab2/preps.page.ts
@@ -3,6 +3,8 @@ import { Storage } from '@ionic/storage';
 import { ToastController } from '@ionic/angular';
 import { Chart } from 'chart.js';
 import 'chartjs-plugin-labels';
+import { IconContractService } from '../services/icon-contract/icon-contract.service';
+import { DelegatedPRep, PReps } from '../services/icon-contract/preps';
 
 @Component({
   selector: 'app-preps',
@@ -17,16 +19,25 @@ export class PrepsPage implements OnInit {
   dn: Chart;
   tablestyle = 'bootstrap';
 
-  prepTotal = 132545535;
+  public address: string;
+  public prepTotal = 132545535;
+  public myPreps: DelegatedPRep;
 
-  constructor() {}
+  constructor( private storage: Storage, 
+               private iconContract: IconContractService) {}
 
   ngAfterViewInit() {
      this.createDnChart();
   }
 
-  ngOnInit(){
-    this.rows = [
+  ngOnInit() {
+    this.storage.get('address').then(address => {
+      this.address = address;     
+      this.getMyPreps();
+    });
+     
+
+     this.rows = [
       {
         "rank": '#2',
         "name": "Ubik",
@@ -48,6 +59,11 @@ export class PrepsPage implements OnInit {
     ];
   }
 
+  async getMyPreps() {
+    this.iconContract.getDelegatedPReps(this.address).then(result => {
+      console.log(result);
+    });
+   }
 
   createDnChart() {
     this.dn = new Chart(this.dnChart.nativeElement, {
@@ -71,6 +87,7 @@ export class PrepsPage implements OnInit {
           borderWidth: 1
         }]
       }, 
+      
       options: {
         legend: {
           display: true,

--- a/src/app/tab2/preps.page.ts
+++ b/src/app/tab2/preps.page.ts
@@ -17,11 +17,8 @@ export class PrepsPage implements OnInit {
   @ViewChild('dnChart', {static:false}) dnChart: ElementRef;
   rows: Object;
   dn: Chart;
-  tablestyle = 'bootstrap';
 
   public address: string;
-  public prepTotal = 132545535;
-  public myPreps: DelegatedPRep;
 
   constructor( private storage: Storage, 
                private iconContract: IconContractService) {}

--- a/src/app/wallet/wallet.page.ts
+++ b/src/app/wallet/wallet.page.ts
@@ -34,7 +34,6 @@ export class WalletPage implements OnInit {
       this.loadWallet();
       this.loadStake();
       this.loadClaim();
-      this.loadUnstakePeriod();
       this.loadChart();
     });
   }
@@ -51,13 +50,10 @@ export class WalletPage implements OnInit {
     this.claim = await this.iconContract.getClaimableRewards(this.address);
   }
 
-  async loadUnstakePeriod() {
-    this.claim = await this.iconContract.getUnstakingPeriod(this.address);  
-  }
 
   async loadChart() {
 
-    await this.iconContract.getPReps(this.address);
+  //  await this.iconContract.getPReps(this.address);
 
     this.barChart = new Chart(this.barCanvas.nativeElement, {
       type: "bar",


### PR DESCRIPTION
What do you think of this? (happy for it to be denied! :D)

1) mapping the array into the Typescript Class makes it neater. (however you lose the nice feature to change the hex value to a number (which you can do later when you use it).

2) included getDelegatedPreps to icon-contract.service
